### PR TITLE
Fix "Show Show Siblings" menu entry

### DIFF
--- a/ShowSiblings.glyphsReporter/Contents/Resources/plugin.py
+++ b/ShowSiblings.glyphsReporter/Contents/Resources/plugin.py
@@ -25,7 +25,7 @@ class ShowSiblings(ReporterPlugin):
 
 	def settings(self):
 
-		self.menuName = Glyphs.localize({'en': u'Show Siblings',}) #  👫
+		self.menuName = Glyphs.localize({'en': u'Siblings',}) #  👫
 
 		try:
 			self.ShowSiblings2ReporterLIB = ShowSiblings2ReporterLIB


### PR DESCRIPTION
`menuName` should not start with _Show_, since the word is added automatically when the menu is created.